### PR TITLE
Delete empty block without confirmation

### DIFF
--- a/src/Editor.svelte
+++ b/src/Editor.svelte
@@ -102,7 +102,7 @@
   };
 
   const removeBlock = (i, force) => {
-    if (force || confirm("Are you sure?")) {
+    if (force || !content.blocks[i].data.text || confirm("Are you sure?")) {
       content.blocks.splice(i, 1);
       onChange();
       refreshContent();


### PR DESCRIPTION
Empty blocks don't need confirmation, since there is no data to lose. Makes it faster to delete a block created by mistake.