### PR TITLE
fix: allow i18n in placeholder & confirmDelete

### DIFF
--- a/src/Editor.svelte
+++ b/src/Editor.svelte
@@ -17,8 +17,6 @@
   export let data;
 
   export let translation = {};
-  export let placeholder = translation.placeholder;
-  export let confirmDelete = translation.confirmDelete;
 
   export const toggleFormat = (tag) => {
     format(tag);
@@ -106,14 +104,14 @@
         <Block
           {block}
           {i}
-          {confirmDelete}
-          {placeholder}
+          confirmDelete={translation.confirmDelete}
+          placeholder={translation.placeholder}
           on:activateHistory={activateHistory} />
       {/each}
       {#if $isActive}
         <Create
           on:create={(e) => content.addBlock(0, e.detail, '')}
-          on:remove={() => content.removeBlock(0, false, confirmDelete)} />
+          on:remove={() => content.removeBlock(0, false, translation.confirmDelete)} />
       {/if}
     {/if}
   </div>

--- a/src/Editor.svelte
+++ b/src/Editor.svelte
@@ -14,11 +14,11 @@
   export let active = true;
   export let spellCheck = false;
   export let sidebar = true;
-  export let placeholder = "Let's write an awesome story!";
-  export let confirmDelete = "Are you sure?";
   export let data;
 
   export let translation = {};
+  export let placeholder = translation.placeholder;
+  export let confirmDelete = translation.confirmDelete;
 
   export const toggleFormat = (tag) => {
     format(tag);


### PR DESCRIPTION
I'm unsure about this PR, but this could allow use translated strings in Editor.

This issue is linked to TorstenDittmann/OmniaWrite#93